### PR TITLE
Fix path to patch file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update; \
 
 RUN cd /app && apt-get source nginx; \ 
     cd /app/ && git clone https://github.com/chobits/ngx_http_proxy_connect_module; \
-    cd /app/nginx-* && patch -p1 < ../ngx_http_proxy_connect_module/proxy_connect.patch; \
+    cd /app/nginx-* && patch -p1 < ../ngx_http_proxy_connect_module/patch/proxy_connect.patch; \
     cd /app/nginx-* && ./configure --add-module=/app/ngx_http_proxy_connect_module && make && make install;
 
 ADD nginx_whitelist.conf /usr/local/nginx/conf/nginx.conf


### PR DESCRIPTION
It seems that upstream [chobits/ngx_http_proxy_connect_module](https://github.com/chobits/ngx_http_proxy_connect_module/tree/002f8f9ef15562dc3691b977134518ad216d7a90) changed their path to patch files.