### PR TITLE
Fix examples by binding files with absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This domains are blocked with the above configuration:
 By starting the Docker container the file can be mounted into the running container. 
 
 ```
-docker run -d -p 8888:8888 -v nginx_whitelist.conf:/usr/local/nginx/conf/nginx.conf reiz/nginx_proxy:0.0.3 
+docker run -d -p 8888:8888 -v ${PWD}/nginx_whitelist.conf:/usr/local/nginx/conf/nginx.conf reiz/nginx_proxy:0.0.3 
 ```
 
 Now the Docker container is running with the mounted configuration.
@@ -109,7 +109,7 @@ In the example above all pages would be accessible, but google.com and all subdo
 By starting the Docker container the file can be mounted into the running container. 
 
 ```
-docker run -d -p 8888:8888 -v nginx_whitelist.conf:/usr/local/nginx/conf/nginx.conf reiz/nginx_proxy:0.0.1 
+docker run -d -p 8888:8888 -v ${PWD}/nginx_whitelist.conf:/usr/local/nginx/conf/nginx.conf reiz/nginx_proxy:0.0.1 
 ```
 
 Now the Docker container is running with the mounted configuration.


### PR DESCRIPTION
Nice work! This is very useful.

When I was trying to run the examples I was presented with the following error message:
```bash
 $ docker run -d -p 8888:8888 -v nginx_whitelist.conf:/usr/local/nginx/conf/nginx.conf reiz/nginx_proxy
docker: Error response from daemon: source /var/lib/docker/overlay2/60c6558e67ba7edf9faf4b40d2a04d65f87e16973d8e6defc887027fe54786a1/merged/usr/local/nginx/conf/nginx.conf is not directory.
See 'docker run --help'.
```

Including the full path with `${PWD}/` fixed it.