### PR TITLE
Allow incoming CONNECT requests over SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ RUN apt-get update; \
     apt-get install -y git; \
     apt-get install -y dpkg-dev; \
     apt-get install -y libpng-dev; \
+    apt-get install -y libssl-dev; \
     apt-get autoclean && apt-get autoremove;
 
 RUN cd /app && apt-get source nginx; \ 
     cd /app/ && git clone https://github.com/chobits/ngx_http_proxy_connect_module; \
     cd /app/nginx-* && patch -p1 < ../ngx_http_proxy_connect_module/patch/proxy_connect_rewrite_1018.patch; \
-    cd /app/nginx-* && ./configure --add-module=/app/ngx_http_proxy_connect_module && make && make install;
+    cd /app/nginx-* && ./configure --add-module=/app/ngx_http_proxy_connect_module --with-http_ssl_module --with-http_stub_status_module --with-http_realip_module --with-threads && make && make install;
 
 ADD nginx_whitelist.conf /usr/local/nginx/conf/nginx.conf
 


### PR DESCRIPTION
Add a new module to the build config for nginx to allow HTTP CONNECT proxy requests using SSL.