### PR TITLE
Use bracket notation in Dockerfile for max compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ ADD nginx_whitelist.conf /usr/local/nginx/conf/nginx.conf
 
 EXPOSE 8888
 
-CMD /usr/local/nginx/sbin/nginx
+CMD ["/usr/local/nginx/sbin/nginx"]


### PR DESCRIPTION
[Some hosted container solutions (like the underlying tech for Google Cloud Run) require the bracket syntax to successfully run the container.](https://stackoverflow.com/questions/61744540/unable-to-deploy-ubuntu-20-04-docker-container-on-google-cloud-run?noredirect=1&lq=1)